### PR TITLE
Fix request headers not being mapped and passed correctly

### DIFF
--- a/WebsocketsSimple.Server/Handlers/WebsocketHandler.cs
+++ b/WebsocketsSimple.Server/Handlers/WebsocketHandler.cs
@@ -1,5 +1,6 @@
 ﻿using PHS.Networking.Events.Args;
 using System;
+using System.Collections.Generic;
 using WebsocketsSimple.Server.Events.Args;
 using WebsocketsSimple.Server.Models;
 
@@ -32,13 +33,14 @@ namespace WebsocketsSimple.Server.Handlers
             };
         }
 
-        protected override WSConnectionServerEventArgs CreateConnectionEventArgs(ConnectionEventArgs<ConnectionWSServer> args)
+        protected override WSConnectionServerEventArgs CreateConnectionEventArgs(WSConnectionServerBaseEventArgs<ConnectionWSServer> args)
         {
             return new WSConnectionServerEventArgs
             {
                 Connection = args.Connection,
                 ConnectionEventType = args.ConnectionEventType,
                 CancellationToken = args.CancellationToken,
+                RequestHeaders = args.RequestHeaders,
             };
         }
 

--- a/WebsocketsSimple.Server/Handlers/WebsocketHandlerAuth.cs
+++ b/WebsocketsSimple.Server/Handlers/WebsocketHandlerAuth.cs
@@ -87,13 +87,14 @@ namespace WebsocketsSimple.Server.Handlers
             };
         }
 
-        protected override WSConnectionServerAuthEventArgs<T> CreateConnectionEventArgs(ConnectionEventArgs<IdentityWSServer<T>> args)
+        protected override WSConnectionServerAuthEventArgs<T> CreateConnectionEventArgs(WSConnectionServerBaseEventArgs<IdentityWSServer<T>> args)
         {
             return new WSConnectionServerAuthEventArgs<T>
             {
                 Connection = args.Connection,
                 ConnectionEventType = args.ConnectionEventType,
-                CancellationToken = args.CancellationToken
+                CancellationToken = args.CancellationToken,
+                RequestHeaders = args.RequestHeaders
             };
         }
 

--- a/WebsocketsSimple.Server/Handlers/WebsocketHandlerBase.cs
+++ b/WebsocketsSimple.Server/Handlers/WebsocketHandlerBase.cs
@@ -248,9 +248,9 @@ namespace WebsocketsSimple.Server.Handlers
                             {
                                 var split = item.Split(":");
 
-                                if (split.Length == 2)
+                                if (split.Length >= 2)
                                 {
-                                    headers.Add(split[0].Trim(), split[1].Trim());
+                                    headers.Add(split[0].Trim(), string.Join(":", split.Skip(1)).Trim());
                                 }
                             }
 
@@ -374,9 +374,9 @@ namespace WebsocketsSimple.Server.Handlers
                             {
                                 var split = item.Split(":");
 
-                                if (split.Length == 2)
+                                if (split.Length >= 2)
                                 {
-                                    headers.Add(split[0].Trim(), split[1].Trim());
+                                    headers.Add(split[0].Trim(), string.Join(":", split.Skip(1)).Trim());
                                 }
                             }
 

--- a/WebsocketsSimple.Server/Handlers/WebsocketHandlerBase.cs
+++ b/WebsocketsSimple.Server/Handlers/WebsocketHandlerBase.cs
@@ -719,7 +719,7 @@ namespace WebsocketsSimple.Server.Handlers
         }
 
         protected abstract Z CreateConnection(ConnectionWSServer connection);
-        protected abstract T CreateConnectionEventArgs(ConnectionEventArgs<Z> args);
+        protected abstract T CreateConnectionEventArgs(WSConnectionServerBaseEventArgs<Z> args);
         protected abstract U CreateMessageEventArgs(WSMessageServerBaseEventArgs<Z> args);
         protected abstract V CreateErrorEventArgs(ErrorEventArgs<Z> args);
 


### PR DESCRIPTION
Found 2 issues:
- Some headers were not being parsed correctly (if they had a : in their value, like Origin or Cookie usually has)
- The headers were not being passed correctly to the event handlers